### PR TITLE
Optional text format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ var api = new ParseServer({
             apiKey: SES_ACCESS_KEY,                         // SES API Key
             apiSecret: SES_SECRET_KEY,                      // SES API Secret
             domain: 'aVerifiedDomain.com',                  // A verified domain in SES
-            amazon: 'https://email.us-east-1.amazonaws.com' // OPTIONAL: Defaults to us-east-1
+            amazon: 'https://email.us-east-1.amazonaws.com',// OPTIONAL: Defaults to us-east-1
+            format: 'html'                                  // OPTIONAL: 'html' (default) or 'text'
         }
     }
 });

--- a/index.js
+++ b/index.js
@@ -17,8 +17,13 @@ var SimpleSESAdapter = sesOptions => {
       to: mail.to,
       from: sesOptions.fromAddress,
       subject: mail.subject,
-      message: mail.text,
     };
+
+    if (sesOptions.format === 'text') {
+      data.altText = mail.text;
+    } else {
+      data.message = mail.text;
+    }
 
     return new Promise((resolve, reject) => {
       client.sendEmail(data, function(err, body, res) {


### PR DESCRIPTION
This PR enables us to specify mail format in the adapter option.

`altText` is pass to [Text](https://docs.aws.amazon.com/ja_jp/ses/latest/APIReference/API_Body.html) field in SES [SendEmail](https://docs.aws.amazon.com/ja_jp/ses/latest/APIReference/API_SendEmail.html) call args.
https://github.com/aheckmann/node-ses/blob/bcd40086/lib/email.js#L94-L102